### PR TITLE
Update DeviceIntegrationService URLs and add new Service classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.app.5gla</groupId>
     <artifactId>fiware-integration-layer</artifactId>
-    <version>4.4.0</version>
+    <version>4.5.0</version>
 
     <name>5gLa FIWARE integration layer</name>
     <url>https://github.com/vitrum-connect/5gla-fiware-integration-layer</url>

--- a/src/main/java/de/app/fivegla/fiware/AbstractEntityIntegrationService.java
+++ b/src/main/java/de/app/fivegla/fiware/AbstractEntityIntegrationService.java
@@ -34,7 +34,7 @@ public abstract class AbstractEntityIntegrationService<T extends Validatable> ex
                 .build();
         var httpClient = HttpClient.newHttpClient();
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/op/update" + "?options=keyValues"))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/op/update" + "?options=keyValues"))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(toJson(updateOrCreateEntityRequest))).build();
         try {
@@ -61,7 +61,7 @@ public abstract class AbstractEntityIntegrationService<T extends Validatable> ex
     public boolean exists(String id) {
         var httpClient = HttpClient.newHttpClient();
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/entities/" + id))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/entities/" + id))
                 .GET().build();
         try {
             var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
@@ -86,7 +86,7 @@ public abstract class AbstractEntityIntegrationService<T extends Validatable> ex
     public Optional<T> read(String id) {
         var httpClient = HttpClient.newHttpClient();
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/entities/" + id + "?options=keyValues"))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/entities/" + id + "?options=keyValues"))
                 .GET().build();
         try {
             var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/de/app/fivegla/fiware/AbstractIntegrationService.java
+++ b/src/main/java/de/app/fivegla/fiware/AbstractIntegrationService.java
@@ -15,10 +15,28 @@ import java.util.List;
 public abstract class AbstractIntegrationService<T> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    final String contextBrokerUrl;
+    private final String contextBrokerUrl;
 
     public AbstractIntegrationService(String contextBrokerUrl) {
         this.contextBrokerUrl = contextBrokerUrl;
+    }
+
+    /**
+     * Returns the URL of the context broker.
+     *
+     * @return the URL of the context broker
+     */
+    String contextBrokerUrl() {
+        return contextBrokerUrl;
+    }
+
+    /**
+     * Returns the URL of the context broker for commands.
+     *
+     * @return the URL of the context broker for commands
+     */
+    String contextBrokerUrlForCommands() {
+        return contextBrokerUrl + "/v2";
     }
 
     /**

--- a/src/main/java/de/app/fivegla/fiware/StatusService.java
+++ b/src/main/java/de/app/fivegla/fiware/StatusService.java
@@ -1,0 +1,47 @@
+package de.app.fivegla.fiware;
+
+import de.app.fivegla.fiware.api.FiwareIntegrationLayerException;
+import de.app.fivegla.fiware.model.Version;
+import de.app.fivegla.fiware.response.VersionResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Slf4j
+public class StatusService extends AbstractIntegrationService<VersionResponse> {
+    public StatusService(String contextBrokerUrl) {
+        super(contextBrokerUrl);
+    }
+
+    /**
+     * Retrieves the version of the context broker.
+     * Makes an HTTP GET request to the specified context broker URL and
+     * parses the response to extract the version information.
+     *
+     * @return the version of the context broker
+     * @throws FiwareIntegrationLayerException if there was an error fetching the version
+     */
+    public Version getVersion() {
+        var httpClient = HttpClient.newHttpClient();
+        var httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(contextBrokerUrl() + "/version"))
+                .header("Accept", "application/json")
+                .GET().build();
+        try {
+            var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                log.error("Could not fetch version. Response: " + response.body());
+                log.debug("Response: " + response.body());
+                throw new FiwareIntegrationLayerException("Could not fetch version, there was an error from FIWARE.");
+            } else {
+                log.info("Subscription created/updated successfully.");
+                return toObject(response.body()).getVersion();
+            }
+        } catch (Exception e) {
+            throw new FiwareIntegrationLayerException("Could not fetch version from FIWARE.", e);
+        }
+    }
+}

--- a/src/main/java/de/app/fivegla/fiware/SubscriptionService.java
+++ b/src/main/java/de/app/fivegla/fiware/SubscriptionService.java
@@ -36,7 +36,7 @@ public class SubscriptionService extends AbstractIntegrationService<Subscription
         var httpClient = HttpClient.newHttpClient();
         var subscription = createSubscriptionForType(type);
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/subscriptions"))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/subscriptions"))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(toJson(subscription))).build();
         try {
@@ -61,7 +61,7 @@ public class SubscriptionService extends AbstractIntegrationService<Subscription
     private void removeSubscription(Subscription subscription) {
         var httpClient = HttpClient.newHttpClient();
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/subscriptions/" + subscription.getId()))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/subscriptions/" + subscription.getId()))
                 .DELETE().build();
         try {
             var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
@@ -80,7 +80,7 @@ public class SubscriptionService extends AbstractIntegrationService<Subscription
     public List<Subscription> findAll(Type type) {
         var httpClient = HttpClient.newHttpClient();
         var httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(contextBrokerUrl + "/subscriptions"))
+                .uri(URI.create(contextBrokerUrlForCommands() + "/subscriptions"))
                 .GET().build();
         try {
             var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/de/app/fivegla/fiware/model/Version.java
+++ b/src/main/java/de/app/fivegla/fiware/model/Version.java
@@ -1,0 +1,67 @@
+package de.app.fivegla.fiware.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a version.
+ */
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Version {
+    /**
+     * The version.
+     */
+    private String version;
+
+    /**
+     * The uptime.
+     */
+    private String uptime;
+
+    /**
+     * The git hash.
+     */
+    @JsonProperty("git_hash")
+    private String gitHash;
+
+    /**
+     * The compile time.
+     */
+    @JsonProperty("compile_time")
+    private String compileTime;
+
+    /**
+     * The compiled by.
+     */
+    @JsonProperty("compiled_by")
+    private String compiledBy;
+
+    /**
+     * The compiled in.
+     */
+    @JsonProperty("compiled_in")
+    private String compiledIn;
+
+    /**
+     * The release date.
+     */
+    @JsonProperty("release_date")
+    private String releaseDate;
+
+    /**
+     * The machine.
+     */
+    private String machine;
+
+    /**
+     * The doc.
+     */
+    private String doc;
+
+}

--- a/src/main/java/de/app/fivegla/fiware/response/VersionResponse.java
+++ b/src/main/java/de/app/fivegla/fiware/response/VersionResponse.java
@@ -1,0 +1,16 @@
+package de.app.fivegla.fiware.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.app.fivegla.fiware.model.Version;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Response wrapper.
+ */
+@Getter
+@Setter
+public class VersionResponse {
+    @JsonProperty("orion")
+    private Version version;
+}

--- a/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceIT.java
@@ -13,7 +13,7 @@ class DeviceIntegrationServiceIT {
 
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
-        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026/v2");
+        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026");
         var device = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         fiwareIntegrationService.persist(device);
         Assertions.assertTrue(fiwareIntegrationService.exists(device.getId()));
@@ -21,7 +21,7 @@ class DeviceIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
-        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026/v2");
+        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026");
         var id = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(id).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         fiwareIntegrationService.persist(device);
@@ -32,7 +32,7 @@ class DeviceIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
-        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026/v2");
+        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026");
         var id = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(id).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         fiwareIntegrationService.persist(device);
@@ -51,7 +51,7 @@ class DeviceIntegrationServiceIT {
 
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
-        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026/v2");
+        var fiwareIntegrationService = new DeviceIntegrationService("http://localhost:1026");
         var id = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(id).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         fiwareIntegrationService.persist(device);

--- a/src/test/java/de/app/fivegla/fiware/DeviceMeasurementIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DeviceMeasurementIntegrationServiceIT.java
@@ -15,7 +15,7 @@ class DeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
-        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026");
         var device = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurement = DeviceMeasurement.builder().id("integration-test:" + UUID.randomUUID()).refDevice(device.getId()).numValue(2.4).location(location).build();
@@ -25,7 +25,7 @@ class DeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
-        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026");
         String deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
@@ -39,7 +39,7 @@ class DeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
-        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026");
         String deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
@@ -63,7 +63,7 @@ class DeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
-        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService("http://localhost:1026");
         String deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();

--- a/src/test/java/de/app/fivegla/fiware/DroneDeviceMeasurementIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DroneDeviceMeasurementIntegrationServiceIT.java
@@ -12,7 +12,7 @@ class DroneDeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
-        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026");
         var device = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurement = DeviceMeasurement.builder().id("integration-test:" + UUID.randomUUID()).refDevice(device.getId()).numValue(2.4).location(location).build();
@@ -23,7 +23,7 @@ class DroneDeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
-        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026");
         var deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
@@ -39,7 +39,7 @@ class DroneDeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
-        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026");
         var deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
@@ -61,7 +61,7 @@ class DroneDeviceMeasurementIntegrationServiceIT {
 
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
-        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026/v2");
+        var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService("http://localhost:1026");
         String deviceId = "integration-test:" + UUID.randomUUID();
         var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();

--- a/src/test/java/de/app/fivegla/fiware/StatusServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/StatusServiceIT.java
@@ -1,0 +1,15 @@
+package de.app.fivegla.fiware;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StatusServiceIT {
+
+    @Test
+    void givenRunningFiwareInstanceWhenFetchingTheVersionThenTheVersionIsReturned() {
+        var version = new StatusService("http://localhost:1026").getVersion();
+        Assertions.assertNotNull(version);
+        Assertions.assertNotNull(version.getVersion());
+    }
+
+}

--- a/src/test/java/de/app/fivegla/fiware/SubscriptionServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/SubscriptionServiceIT.java
@@ -9,13 +9,13 @@ class SubscriptionServiceIT {
 
     @AfterEach
     void tearDown() {
-        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026/v2", "http://192.168.56.1:5055/notify");
+        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026", "http://192.168.56.1:5055/notify");
         fiwareIntegrationService.removeAll(Type.Device);
     }
 
     @Test
     void givenValidSubscriptionWhenSendingSubscriptionToFiwareThereShouldBeNoError() {
-        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026/v2", "http://192.168.56.1:5055/notify");
+        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026", "http://192.168.56.1:5055/notify");
         fiwareIntegrationService.subscribe(Type.Device);
         var subscriptions = fiwareIntegrationService.findAll(Type.Device);
         Assertions.assertNotNull(subscriptions);
@@ -23,7 +23,7 @@ class SubscriptionServiceIT {
 
     @Test
     void givenExistingSubscriptionWhenRemovingAllSubscriptionsTheNumberOfExistingSubscriptionsShouldBeNull() {
-        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026/v2", "http://192.168.56.1:5055/notify");
+        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026", "http://192.168.56.1:5055/notify");
         fiwareIntegrationService.subscribe(Type.Device);
         var subscriptions = fiwareIntegrationService.findAll(Type.Device);
         Assertions.assertNotNull(subscriptions);
@@ -36,7 +36,7 @@ class SubscriptionServiceIT {
 
     @Test
     void givenExistingSubscriptionWhenSubscribingAndResettingTheNumberOfExistingSubscriptionsShouldStayTheSame() {
-        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026/v2", "http://192.168.56.1:5055/notify");
+        var fiwareIntegrationService = new SubscriptionService("http://localhost:1026", "http://192.168.56.1:5055/notify");
         fiwareIntegrationService.subscribe(Type.Device);
         var subscriptions = fiwareIntegrationService.findAll(Type.Device);
         Assertions.assertNotNull(subscriptions);


### PR DESCRIPTION
Changed the URLs used in DeviceIntegrationService to properly route requests to "http://localhost:1026" instead of "http://localhost:1026/v2". Also a StatusService class was added which retrieves version information from the context broker. Similarly, a Version model was added to map the version information.

AbstractIntegrationService now has functions for returning the context broker's base URL and command URL separately. Integration tests were also updated accordingly. These changes improve the modularity and readability of the code, making the service classes more dynamic and reusable.