### PR TITLE
Add 'failed' status to SubscriptionStatus enum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.app.5gla</groupId>
     <artifactId>fiware-integration-layer</artifactId>
-    <version>5.3.0</version>
+    <version>5.4.0</version>
 
     <name>5gLa FIWARE integration layer</name>
     <url>https://github.com/vitrum-connect/5gla-fiware-integration-layer</url>

--- a/src/main/java/de/app/fivegla/fiware/model/enums/SubscriptionStatus.java
+++ b/src/main/java/de/app/fivegla/fiware/model/enums/SubscriptionStatus.java
@@ -4,5 +4,6 @@ public enum SubscriptionStatus {
     active,
     inactive,
     expired,
-    error
+    error,
+    failed
 }


### PR DESCRIPTION
A new 'failed' status was added to the SubscriptionStatus enum in the SubscriptionStatus.java file. This change is necessary to comprehensively capture all potential outcomes of a subscription event and improve handling of these states.