### PR TITLE
Add manufacturerSpecificId to Device model and tests

### DIFF
--- a/src/main/java/de/app/fivegla/fiware/model/Device.java
+++ b/src/main/java/de/app/fivegla/fiware/model/Device.java
@@ -30,6 +30,11 @@ public class Device implements Validatable {
     private String id;
 
     /**
+     * The manufacturer ID of the device.
+     */
+    private String manufacturerSpecificId;
+
+    /**
      * The category of the device.
      */
     private DeviceCategory deviceCategory;
@@ -43,6 +48,9 @@ public class Device implements Validatable {
     public void validate() {
         if (StringUtils.isBlank(id)) {
             throw new IllegalArgumentException("The id of the device must not be null.");
+        }
+        if (StringUtils.isBlank(manufacturerSpecificId)) {
+            throw new IllegalArgumentException("The manufacturer specific id of the device must not be null.");
         }
         if (deviceCategory == null) {
             throw new IllegalArgumentException("The device category of the device must not be null.");

--- a/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceBasedOnTenantIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceBasedOnTenantIT.java
@@ -3,6 +3,7 @@ package de.app.fivegla.fiware;
 import de.app.fivegla.fiware.api.enums.DeviceCategoryValues;
 import de.app.fivegla.fiware.model.Device;
 import de.app.fivegla.fiware.model.DeviceCategory;
+import de.app.fivegla.fiware.model.Location;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,9 +16,29 @@ class DeviceIntegrationServiceBasedOnTenantIT extends AbstractIT {
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
         var fiwareIntegrationServiceForFoo = new DeviceIntegrationService(contextBrokerUrl, "foo");
         var fiwareIntegrationServiceForBar = new DeviceIntegrationService(contextBrokerUrl, "bar");
+        var manufacturerSpecificIdForFoo = UUID.randomUUID().toString();
+        var manufacturerSpecificIdForBar = UUID.randomUUID().toString();
 
-        var deviceForFoo = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
-        var deviceForBar = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.Farm21Sensor.getKey())).build()).build();
+        var deviceForFoo = Device.builder()
+                .id("integration-test:" + manufacturerSpecificIdForFoo)
+                .manufacturerSpecificId(manufacturerSpecificIdForFoo)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
+        var deviceForBar = Device.builder()
+                .id("integration-test:" + manufacturerSpecificIdForBar)
+                .manufacturerSpecificId(manufacturerSpecificIdForBar)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.Farm21Sensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
 
         fiwareIntegrationServiceForFoo.persist(deviceForFoo);
         fiwareIntegrationServiceForBar.persist(deviceForBar);

--- a/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DeviceIntegrationServiceIT.java
@@ -16,8 +16,11 @@ class DeviceIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
         var fiwareIntegrationService = new DeviceIntegrationService(contextBrokerUrl, tenant);
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var id = "integration-test:" + manufacturerSpecificId;
         var device = Device.builder()
-                .id("integration-test:" + UUID.randomUUID())
+                .id(id)
+                .manufacturerSpecificId(manufacturerSpecificId)
                 .deviceCategory(DeviceCategory.builder()
                         .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
                         .build())
@@ -32,9 +35,11 @@ class DeviceIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
         var fiwareIntegrationService = new DeviceIntegrationService(contextBrokerUrl, tenant);
-        var id = "integration-test:" + UUID.randomUUID();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var id = "integration-test:" + manufacturerSpecificId;
         var device = Device.builder()
                 .id(id)
+                .manufacturerSpecificId(manufacturerSpecificId)
                 .deviceCategory(DeviceCategory.builder()
                         .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
                         .build())
@@ -51,9 +56,11 @@ class DeviceIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
         var fiwareIntegrationService = new DeviceIntegrationService(contextBrokerUrl, tenant);
-        var id = "integration-test:" + UUID.randomUUID();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var id = "integration-test:" + manufacturerSpecificId;
         var device = Device.builder()
                 .id(id)
+                .manufacturerSpecificId(manufacturerSpecificId)
                 .deviceCategory(DeviceCategory.builder()
                         .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
                         .build())
@@ -78,9 +85,11 @@ class DeviceIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
         var fiwareIntegrationService = new DeviceIntegrationService(contextBrokerUrl, tenant);
-        var id = "integration-test:" + UUID.randomUUID();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var id = "integration-test:" + manufacturerSpecificId;
         var device = Device.builder()
                 .id(id)
+                .manufacturerSpecificId(manufacturerSpecificId)
                 .deviceCategory(DeviceCategory.builder()
                         .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
                         .build())
@@ -96,9 +105,11 @@ class DeviceIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingDeviceWhenDeletingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
         var fiwareIntegrationService = new DeviceIntegrationService(contextBrokerUrl, tenant);
-        var id = "integration-test:" + UUID.randomUUID();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var id = "integration-test:" + manufacturerSpecificId;
         var device = Device.builder()
                 .id(id)
+                .manufacturerSpecificId(manufacturerSpecificId)
                 .deviceCategory(DeviceCategory.builder()
                         .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
                         .build())

--- a/src/test/java/de/app/fivegla/fiware/DeviceMeasurementIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DeviceMeasurementIntegrationServiceIT.java
@@ -16,7 +16,18 @@ class DeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
         var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        var device = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurement = DeviceMeasurement.builder().id("integration-test:" + UUID.randomUUID()).refDevice(device.getId()).numValue(2.4).location(location).build();
         deviceMeasurementIntegrationService.persist(deviceMeasurement);
@@ -26,8 +37,18 @@ class DeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
         var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        String deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         String deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var deviceMeasurement = DeviceMeasurement.builder().id(deviceMeasurementId).refDevice(device.getId()).numValue(2.4).location(location).build();
@@ -40,8 +61,18 @@ class DeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
         var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        String deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         String deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var deviceMeasurement = DeviceMeasurement.builder().id(deviceMeasurementId).refDevice(device.getId()).numValue(2.4).location(location).build();
@@ -64,8 +95,18 @@ class DeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
         var deviceMeasurementIntegrationService = new DeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        String deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         String deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var deviceMeasurement = DeviceMeasurement.builder().id(deviceMeasurementId).refDevice(device.getId()).numValue(2.4).location(location).build();

--- a/src/test/java/de/app/fivegla/fiware/DroneDeviceMeasurementIntegrationServiceIT.java
+++ b/src/test/java/de/app/fivegla/fiware/DroneDeviceMeasurementIntegrationServiceIT.java
@@ -13,7 +13,18 @@ class DroneDeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingPackagePropertiesWhenFetchingTheVersionTheServiceShouldReturnTheCurrentVersion() {
         var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        var device = Device.builder().id("integration-test:" + UUID.randomUUID()).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurement = DeviceMeasurement.builder().id("integration-test:" + UUID.randomUUID()).refDevice(device.getId()).numValue(2.4).location(location).build();
         var droneDeviceMeasurement = DroneDeviceMeasurement.builder().id("integration-test:" + UUID.randomUUID()).deviceMeasurement(deviceMeasurement).channel("red").imagePath("http://localhost:8080/images/" + UUID.randomUUID()).build();
@@ -24,8 +35,18 @@ class DroneDeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenCreatingNewDevicesTheServiceShouldNotThrowAnException() {
         var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        var deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var droneDeviceMeasurementId = "integration-test:" + UUID.randomUUID();
@@ -40,8 +61,18 @@ class DroneDeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenAlreadyExistingDeviceWhenUpdatingTheDeviceTheServiceShouldUpdateTheValuesForTheDevice() {
         var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        var deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         var deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var droneDeviceMeasurementId = "integration-test:" + UUID.randomUUID();
@@ -62,8 +93,18 @@ class DroneDeviceMeasurementIntegrationServiceIT extends AbstractIT {
     @Test
     void givenExistingDeviceWhenCheckingIfTheDeviceDoesExistTheServiceShouldReturnTrue() {
         var deviceMeasurementIntegrationService = new DroneDeviceMeasurementIntegrationService(contextBrokerUrl, tenant);
-        String deviceId = "integration-test:" + UUID.randomUUID();
-        var device = Device.builder().id(deviceId).deviceCategory(DeviceCategory.builder().value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey())).build()).build();
+        var manufacturerSpecificId = UUID.randomUUID().toString();
+        var deviceId = "integration-test:" + manufacturerSpecificId;
+        var device = Device.builder()
+                .id(deviceId)
+                .manufacturerSpecificId(manufacturerSpecificId)
+                .deviceCategory(DeviceCategory.builder()
+                        .value(List.of(DeviceCategoryValues.SoilScoutSensor.getKey()))
+                        .build())
+                .location(Location.builder()
+                        .coordinates(List.of(2.0, 4.0))
+                        .build())
+                .build();
         var location = Location.builder().coordinates(List.of(1.0, 2.0)).build();
         String deviceMeasurementId = "integration-test:" + UUID.randomUUID();
         var droneDeviceMeasurementId = "integration-test:" + UUID.randomUUID();


### PR DESCRIPTION
Updated the Device model to include the 'manufacturerSpecificId' field and modified all the 'DeviceIntegrationService*' and 'DroneDeviceMeasurementIntegrationService' integration tests to include the 'manufacturerSpecificId' in their respective Device builder. This change ensures more detailed device identification and improved traceability in device-related operations in the system.