### PR TITLE
Bump version and refactor FiwareIdGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.app.5gla</groupId>
     <artifactId>fiware-integration-layer</artifactId>
-    <version>6.3.0</version>
+    <version>6.4.0</version>
 
     <name>5gLa FIWARE integration layer</name>
     <url>https://github.com/vitrum-connect/5gla-fiware-integration-layer</url>

--- a/src/main/java/de/app/fivegla/fiware/api/FiwareIdGenerator.java
+++ b/src/main/java/de/app/fivegla/fiware/api/FiwareIdGenerator.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 @Slf4j
 public final class FiwareIdGenerator {
 
+    public static final int MAX_ID_LENGTH = 62;
+
     private FiwareIdGenerator() {
         // private constructor to prevent instantiation
     }
@@ -27,12 +29,9 @@ public final class FiwareIdGenerator {
     public static String id(String prefix) {
         var randomUUIDParts = UUID.randomUUID().toString().split("-");
         var fiwareId = prefix + randomUUIDParts[0] + randomUUIDParts[1];
-        if (fiwareId.length() > 62) {
-            throw new FiwareIntegrationLayerException("The generated id is too long. Please choose a shorter prefix.");
-        } else {
-            log.debug("Generated id: " + fiwareId);
-            return fiwareId;
-        }
+        check(fiwareId);
+        log.debug("Generated id: " + fiwareId);
+        return fiwareId;
     }
 
     /**
@@ -42,6 +41,20 @@ public final class FiwareIdGenerator {
      */
     public static String id() {
         return id("");
+    }
+
+    /**
+     * Checks if the given ID is valid.
+     *
+     * @param id the ID to be checked
+     * @throws FiwareIntegrationLayerException if the ID is too long
+     */
+    public static void check(String id) {
+        if (id.length() > MAX_ID_LENGTH) {
+            log.error("The id is too long. Please choose a shorter prefix.");
+            log.debug("Checked ID: " + id);
+            throw new FiwareIntegrationLayerException("The generated id is too long. Please choose a shorter prefix.");
+        }
     }
 
 }


### PR DESCRIPTION
Version in pom.xml bumped from 6.3.0 to 6.4.0. FiwareIdGenerator updated to a utility class by making it final and adding a private constructor, reducing chance of misuse. MAX_ID_LENGTH constant introduced to validate generated ID length, ensuring adherence to fiware specifications. This makes the code cleaner, and easier to debug and maintain.